### PR TITLE
fix: send card information towards CardDisconnected event

### DIFF
--- a/src/Lando/Cardreader.cs
+++ b/src/Lando/Cardreader.cs
@@ -158,10 +158,12 @@ namespace Lando
 
 		internal virtual void OnCardDisconnected(object sender, WatcherCardEventArgs e)
 		{
+			var card = new ContactlessCard(e.Card);
+
 			Logger.TraceEvent(TraceEventType.Verbose, 0, "Cardreader: Save invocation of CardDisconnected");
 			Logger.Flush();
 
-			CardDisconnected.SafeInvoke(this, new CardreaderEventArgs((string)null));
+			CardDisconnected.SafeInvoke(this, new CardreaderEventArgs(card, e.Card.CardreaderName);
 		}
 	}
 }

--- a/src/Lando/Watcher/Watcher.cs
+++ b/src/Lando/Watcher/Watcher.cs
@@ -224,7 +224,7 @@ namespace Lando.Watcher
 
 								// reset previously connected card and raise the card connected event
 								ForgotAboutCardreaderHadCard(cardreaderStatus.Name);
-								RaiseCardDisconnectedEvent();
+								RaiseCardDisconnectedEvent(currentCard);
 							}
 						}
 						if (newStatuses.Contains(CardreaderStatus.StatusType.CardreaderDisconnected))
@@ -256,12 +256,12 @@ namespace Lando.Watcher
 			AsyncOperation.Post(cb, null);
 		}
 
-		private void RaiseCardDisconnectedEvent()
+		private void RaiseCardDisconnectedEvent(Card connectedLowlevelCard)
 		{
 			Logger.TraceEvent(TraceEventType.Verbose, 0, "Raising CardDisconnected event");
 			Logger.Flush();
 
-			SendOrPostCallback cb = state => CardDisconnected(null, new WatcherCardEventArgs());
+			SendOrPostCallback cb = state => CardDisconnected(null, new WatcherCardEventArgs(connectedLowlevelCard));
 			AsyncOperation.Post(cb, null);
 		}
 


### PR DESCRIPTION
The bug was that CardDisconnected event fired without any information passed to it. If this is used in a context where multiple readers submit information to one PC, this event did not allow recognizing which specific reader just had a card disconnected from it.

This commit passes the
`var currentCard = LastConnectedCard(...)`
to the "raise method" call and passes non-null CardreaderEventArgs from Cardreader.OnCardDisconnected() .